### PR TITLE
feat: pass query params to GET routes

### DIFF
--- a/src/TestRoute.tsx
+++ b/src/TestRoute.tsx
@@ -40,6 +40,7 @@ const TestRoute: React.FC<TestRouteProps> = ({
     const [verb, setVerb] = useState<Verb>('GET')
     const [body, setBody] = useState<string>()
     const [wildcard, setWildcard] = useState<string>()
+    const [queryParams, setQueryParams] = useState<string>()
     const [result, setResult] = useState<unknown>('')
     const [loading, setLoading] = useState<boolean>(false)
 
@@ -68,8 +69,14 @@ const TestRoute: React.FC<TestRouteProps> = ({
             setResult(undefined)
             setLoading(true)
 
+            const queryPrefix = queryParams?.startsWith('?') ? '' : '?'
+
             const resource = `routes/${route.id ?? route.code}/run${
-                wildcard ? `/${wildcard}` : ''
+                wildcard
+                    ? `/${wildcard}`
+                    : queryParams
+                    ? `${queryPrefix}${queryParams}`
+                    : ''
             }`
 
             if (verb === 'GET') {
@@ -181,6 +188,15 @@ const TestRoute: React.FC<TestRouteProps> = ({
                             value={wildcard}
                             onChange={({ value }) => setWildcard(value)}
                             label={i18n.t('Wildcard path')}
+                        />
+                    )}
+
+                    {verb === 'GET' && !hasWildCardPath && (
+                        <InputField
+                            value={queryParams}
+                            placeholder={'query1=value&query2=value2...'}
+                            onChange={({ value }) => setQueryParams(value)}
+                            label={i18n.t('Query Params')}
                         />
                     )}
 


### PR DESCRIPTION
Implements [18257](https://dhis2.atlassian.net/browse/DHIS2-18257)

--------

**Description**
- A user can now add query params through a separate text field conditionally rendered for GET requests.
-  If the prefix(?) is not included by the user, it will be appended to the query params before the request is made.
 
Screenshots
1. With query params prefix (?)
<img width="621" alt="with-prefix" src="https://github.com/user-attachments/assets/ecad2d6b-ee49-4e1d-abf6-0f035658601c">

2. Without query prefix (?)
<img width="618" alt="without prefix" src="https://github.com/user-attachments/assets/a725dc2b-1a99-4311-bf7f-f51ba2865fe2">
