### PR TITLE
feat(ux): improve authenticatin field display with properly formatted auth details - DHIS2-20757

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,44 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-11-25T11:22:10.945Z\n"
-"PO-Revision-Date: 2025-11-25T11:22:10.945Z\n"
-
-msgid "Failed to invoke route: {{error}}"
-msgstr "Failed to invoke route: {{error}}"
-
-msgid "Route invoked successfully"
-msgstr "Route invoked successfully"
-
-msgid "Test Route"
-msgstr "Test Route"
-
-msgid "Cancel"
-msgstr "Cancel"
-
-msgid "Route code"
-msgstr "Route code"
-
-msgid "Route Name"
-msgstr "Route Name"
-
-msgid "Route URL"
-msgstr "Route URL"
-
-msgid "Wildcard path"
-msgstr "Wildcard path"
-
-msgid "Query Params"
-msgstr "Query Params"
-
-msgid "Use valid JSON for this field (i.e. double quoted properties etc..)"
-msgstr "Use valid JSON for this field (i.e. double quoted properties etc..)"
-
-msgid "Body to pass to route"
-msgstr "Body to pass to route"
-
-msgid "Body of request"
-msgstr "Body of request"
+"POT-Creation-Date: 2026-01-28T09:42:26.313Z\n"
+"PO-Revision-Date: 2026-01-28T09:42:26.314Z\n"
 
 msgid "Authorities"
 msgstr "Authorities"
@@ -110,11 +74,27 @@ msgstr "Edit route: {{name}}"
 msgid "Create route"
 msgstr "Create route"
 
-msgid "A unique code for the route"
-msgstr "A unique code for the route"
+msgid ""
+"A unique code for the route, which can be used as the URL segment to run "
+"the route, e.g. /api/routes/my-route/run"
+msgstr ""
+"A unique code for the route, which can be used as the URL segment to run "
+"the route, e.g. /api/routes/my-route/run"
 
-msgid "A unique user-friendly name for the route"
-msgstr "A unique user-friendly name for the route"
+msgid "e.g. my-route"
+msgstr "e.g. my-route"
+
+msgid "Route code"
+msgstr "Route code"
+
+msgid "A unique, human-readable name for the route"
+msgstr "A unique, human-readable name for the route"
+
+msgid "e.g. My Route"
+msgstr "e.g. My Route"
+
+msgid "Route Name"
+msgstr "Route Name"
 
 msgid "e.g. https://postman-echo.com/get"
 msgstr "e.g. https://postman-echo.com/get"
@@ -124,6 +104,9 @@ msgstr "URL for route destination"
 
 msgid "Save Route"
 msgstr "Save Route"
+
+msgid "Cancel"
+msgstr "Cancel"
 
 msgid ""
 "Enter a valid URL, for example http://localhost:5000/path or "
@@ -180,6 +163,9 @@ msgstr "Authentication"
 msgid "No routes configured yet."
 msgstr "No routes configured yet."
 
+msgid "No authentication"
+msgstr "No authentication"
+
 msgid "Enable route"
 msgstr "Enable route"
 
@@ -188,3 +174,30 @@ msgstr "Test route"
 
 msgid "Edit route"
 msgstr "Edit route"
+
+msgid "Failed to invoke route: {{error}}"
+msgstr "Failed to invoke route: {{error}}"
+
+msgid "Route invoked successfully"
+msgstr "Route invoked successfully"
+
+msgid "Test Route"
+msgstr "Test Route"
+
+msgid "Route URL"
+msgstr "Route URL"
+
+msgid "Wildcard path"
+msgstr "Wildcard path"
+
+msgid "Query Params"
+msgstr "Query Params"
+
+msgid "Use valid JSON for this field (i.e. double quoted properties etc..)"
+msgstr "Use valid JSON for this field (i.e. double quoted properties etc..)"
+
+msgid "Body to pass to route"
+msgstr "Body to pass to route"
+
+msgid "Body of request"
+msgstr "Body of request"

--- a/src/components/route-list/RoutesList.spec.tsx
+++ b/src/components/route-list/RoutesList.spec.tsx
@@ -543,6 +543,133 @@ describe('testing routes', () => {
     })
 })
 
+describe('authentication display', () => {
+    // Checks the display in the Datatablecell. Tests for auth variations (none, basic, api key, oauth - new authentications can be added here)
+    const authTestCases = [
+        {
+            name: 'http-basic with username',
+            auth: { type: 'http-basic', username: 'admin' },
+            expectedType: 'http-basic',
+            expectedDetails: ['username:', 'admin'],
+        },
+        {
+            name: 'api-token with no additional fields',
+            auth: { type: 'api-token' },
+            expectedType: 'api-token',
+            expectedDetails: [],
+        },
+        {
+            name: 'oauth2-client-credentials with clientId and tokenUri',
+            auth: {
+                type: 'oauth2-client-credentials',
+                clientId: 'my-client-id',
+                tokenUri: 'https://dhis2.org/oauth/token',
+            },
+            expectedType: 'oauth2-client-credentials',
+            expectedDetails: [
+                'clientId:',
+                'my-client-id',
+                'tokenUri:',
+                'https://dhis2.org/oauth/token',
+            ],
+        },
+    ]
+    it.each(authTestCases)(
+        'should display $name correctly',
+        async ({ auth, expectedType, expectedDetails }) => {
+            const routeWithAuth = {
+                routes: [
+                    {
+                        id: 'test-id',
+                        code: 'test-code',
+                        name: 'test-name',
+                        url: 'https://example.com',
+                        disabled: false,
+                        auth,
+                    },
+                ],
+            }
+            const { findByText } = render(
+                <TestComponentWithRouter
+                    path="/"
+                    customData={{
+                        authorities: [],
+                        routes: routeWithAuth,
+                        me: {},
+                    }}
+                >
+                    <RoutesList />
+                </TestComponentWithRouter>
+            )
+            // Verify auth type is displayed
+            expect(await findByText(expectedType)).toBeInTheDocument()
+            // Verify additional details are visible (no hover needed!)
+            for (const detail of expectedDetails) {
+                expect(await findByText(new RegExp(detail))).toBeInTheDocument()
+            }
+        }
+    )
+    it('should display "No authentication" when no auth configured', async () => {
+        const routeWithoutAuth = {
+            routes: [
+                {
+                    id: 'test-id',
+                    code: 'test-code',
+                    name: 'test-name',
+                    url: 'https://example.com',
+                    disabled: false,
+                    auth: null,
+                },
+            ],
+        }
+        const { findByText } = render(
+            <TestComponentWithRouter
+                path="/"
+                customData={{
+                    authorities: [],
+                    routes: routeWithoutAuth,
+                    me: {},
+                }}
+            >
+                <RoutesList />
+            </TestComponentWithRouter>
+        )
+        await findByText('No authentication')
+    })
+    it('should not show type field in details', async () => {
+        const routeWithBasicAuth = {
+            routes: [
+                {
+                    id: 'test-id',
+                    code: 'test-code',
+                    name: 'test-name',
+                    url: 'https://example.com',
+                    disabled: false,
+                    auth: {
+                        type: 'http-basic',
+                        username: 'admin',
+                    },
+                },
+            ],
+        }
+        const { findByText, queryByText } = render(
+            <TestComponentWithRouter
+                path="/"
+                customData={{
+                    authorities: [],
+                    routes: routeWithBasicAuth,
+                    me: {},
+                }}
+            >
+                <RoutesList />
+            </TestComponentWithRouter>
+        )
+        await findByText('http-basic')
+        // Verify 'type:' is NOT shown in the details section
+        expect(queryByText(/^type:/i)).not.toBeInTheDocument()
+    })
+})
+
 const mockRoutes = {
     pager: {
         page: 1,

--- a/src/components/route-list/RoutesList.spec.tsx
+++ b/src/components/route-list/RoutesList.spec.tsx
@@ -550,7 +550,7 @@ describe('authentication display', () => {
             name: 'http-basic with username',
             auth: { type: 'http-basic', username: 'admin' },
             expectedType: 'http-basic',
-            expectedDetails: ['username:', 'admin'],
+            expectedDetails: ['username:admin'],
         },
         {
             name: 'api-token with no additional fields',
@@ -569,8 +569,7 @@ describe('authentication display', () => {
             expectedDetails: [
                 'clientId:',
                 'my-client-id',
-                'tokenUri:',
-                'https://dhis2.org/oauth/token',
+                'tokenUri:https://dhis2.org/oauth/token',
             ],
         },
     ]
@@ -605,7 +604,9 @@ describe('authentication display', () => {
             expect(await findByText(expectedType)).toBeInTheDocument()
             // Verify additional details are visible (no hover needed!)
             for (const detail of expectedDetails) {
-                expect(await findByText(new RegExp(detail))).toBeInTheDocument()
+                expect(
+                    await findByText(detail, { exact: false })
+                ).toBeInTheDocument()
             }
         }
     )

--- a/src/components/route-list/RoutesTable.module.css
+++ b/src/components/route-list/RoutesTable.module.css
@@ -4,3 +4,19 @@
     text-wrap: nowrap;
     justify-items: center;
 }
+
+.authDetails {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.authType {
+    font-size: 14px;
+}
+
+.authField {
+    font-size: 12px;
+    color: #404b5a; /* colors.grey700 */
+    line-height: 14px;
+}

--- a/src/components/route-list/RoutesTable.module.css
+++ b/src/components/route-list/RoutesTable.module.css
@@ -17,6 +17,6 @@
 
 .authField {
     font-size: 12px;
-    color: #404b5a; /* colors.grey700 */
-    line-height: 14px;
+    color: var(--colors-grey700);
+    line-height: var(--spacers-dp16);
 }

--- a/src/components/route-list/RoutesTable.tsx
+++ b/src/components/route-list/RoutesTable.tsx
@@ -95,28 +95,31 @@ const RoutesTable: React.FC<RoutesTableProps> = ({
                             <DataTableCell>{route.url}</DataTableCell>
                             <DataTableCell>
                                 {route.auth ? (
-                                    <div className={styles.authDetails}>
-                                        <div className={styles.authType}>
-                                            {route.auth.type}
+                                    <DataTableCell>
+                                        <div className={styles.authDetails}>
+                                            <span className={styles.authType}>
+                                                {route.auth.type}
+                                            </span>
+                                            {Object.entries(route.auth)
+                                                .filter(
+                                                    ([key]) => key !== 'type'
+                                                )
+                                                .map(([key, value]) => (
+                                                    <span
+                                                        key={key}
+                                                        className={
+                                                            styles.authField
+                                                        }
+                                                    >
+                                                        {key}:{String(value)}
+                                                    </span>
+                                                ))}
                                         </div>
-                                        {Object.entries(
-                                            route.auth as Record<
-                                                string,
-                                                unknown
-                                            >
-                                        )
-                                            .filter(([key]) => key !== 'type')
-                                            .map(([key, value]) => (
-                                                <div
-                                                    key={key}
-                                                    className={styles.authField}
-                                                >
-                                                    {key}:{String(value)}
-                                                </div>
-                                            ))}
-                                    </div>
+                                    </DataTableCell>
                                 ) : (
-                                    <div>{i18n.t('No authentication')}</div>
+                                    <DataTableCell muted>
+                                        {i18n.t('No authentication')}
+                                    </DataTableCell>
                                 )}
                             </DataTableCell>
                             <DataTableCell>

--- a/src/components/route-list/RoutesTable.tsx
+++ b/src/components/route-list/RoutesTable.tsx
@@ -93,35 +93,29 @@ const RoutesTable: React.FC<RoutesTableProps> = ({
                             <DataTableCell>{route.code}</DataTableCell>
                             <DataTableCell>{route.name}</DataTableCell>
                             <DataTableCell>{route.url}</DataTableCell>
-                            <DataTableCell>
-                                {route.auth ? (
-                                    <DataTableCell>
-                                        <div className={styles.authDetails}>
-                                            <span className={styles.authType}>
-                                                {route.auth.type}
-                                            </span>
-                                            {Object.entries(route.auth)
-                                                .filter(
-                                                    ([key]) => key !== 'type'
-                                                )
-                                                .map(([key, value]) => (
-                                                    <span
-                                                        key={key}
-                                                        className={
-                                                            styles.authField
-                                                        }
-                                                    >
-                                                        {key}:{String(value)}
-                                                    </span>
-                                                ))}
-                                        </div>
-                                    </DataTableCell>
-                                ) : (
-                                    <DataTableCell muted>
-                                        {i18n.t('No authentication')}
-                                    </DataTableCell>
-                                )}
-                            </DataTableCell>
+                            {route.auth ? (
+                                <DataTableCell>
+                                    <div className={styles.authDetails}>
+                                        <span className={styles.authType}>
+                                            {route.auth.type}
+                                        </span>
+                                        {Object.entries(route.auth)
+                                            .filter(([key]) => key !== 'type')
+                                            .map(([key, value]) => (
+                                                <span
+                                                    key={key}
+                                                    className={styles.authField}
+                                                >
+                                                    {key}:{String(value)}
+                                                </span>
+                                            ))}
+                                    </div>
+                                </DataTableCell>
+                            ) : (
+                                <DataTableCell muted>
+                                    {i18n.t('No authentication')}
+                                </DataTableCell>
+                            )}
                             <DataTableCell>
                                 <ul
                                     style={{

--- a/src/components/route-list/RoutesTable.tsx
+++ b/src/components/route-list/RoutesTable.tsx
@@ -95,9 +95,28 @@ const RoutesTable: React.FC<RoutesTableProps> = ({
                             <DataTableCell>{route.url}</DataTableCell>
                             <DataTableCell>
                                 {route.auth ? (
-                                    <pre>{JSON.stringify(route.auth)}</pre>
+                                    <div className={styles.authDetails}>
+                                        <div className={styles.authType}>
+                                            {route.auth.type}
+                                        </div>
+                                        {Object.entries(
+                                            route.auth as Record<
+                                                string,
+                                                unknown
+                                            >
+                                        )
+                                            .filter(([key]) => key !== 'type')
+                                            .map(([key, value]) => (
+                                                <div
+                                                    key={key}
+                                                    className={styles.authField}
+                                                >
+                                                    {key}:{String(value)}
+                                                </div>
+                                            ))}
+                                    </div>
                                 ) : (
-                                    'n/a'
+                                    <div>{i18n.t('No authentication')}</div>
                                 )}
                             </DataTableCell>
                             <DataTableCell>


### PR DESCRIPTION
Implements [DHIS2-20757](https://dhis2.atlassian.net/browse/DHIS2-20757)

- Replace the raw JSON authentication display in the DataTableCell with properly formatted authentication type and details:
- All auth details are visible in the table cell without cluttering the table
- Display auth type in the main line
- Sort the additional details (flex-direction: column)
- Display auth type as primary text (14px)
- Display additional fields as secondary text below (12px, grey700)

[DHIS2-20757]: https://dhis2.atlassian.net/browse/DHIS2-20757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ