### PR TITLE
fix: auto hide error toast 10 seconds

### DIFF
--- a/src/TestRoute.tsx
+++ b/src/TestRoute.tsx
@@ -46,7 +46,7 @@ const TestRoute: React.FC<TestRouteProps> = ({
 
     const engine = useDataEngine()
 
-    const { show } = useAlert(
+    const { show, hide } = useAlert(
         ({ error }) => {
             if (error) {
                 return i18n.t('Failed to invoke route: {{error}}', {
@@ -66,6 +66,7 @@ const TestRoute: React.FC<TestRouteProps> = ({
 
     const handleTestRoute = async () => {
         try {
+            hide()
             setResult(undefined)
             setLoading(true)
 
@@ -115,6 +116,7 @@ const TestRoute: React.FC<TestRouteProps> = ({
         } catch (error) {
             console.error(error)
             show({ error })
+            setTimeout(hide, 10000)
         } finally {
             setLoading(false)
         }


### PR DESCRIPTION
To avoid persistent toasts:
- Call hide toast method before testing the route to ensure that the new notification is triggered and visible.